### PR TITLE
added playsInline attribute

### DIFF
--- a/src/components/video.js
+++ b/src/components/video.js
@@ -7,6 +7,7 @@ export default ({ src }) => {
             autoPlay
             muted
             loop
+            playsInline
             style={{
                 position: 'absolute',
                 top: 0,


### PR DESCRIPTION
This allows Safari Mobile to play the video in the page rather than take over full screen on play.  The attribute must be in camelCase just like autoPlay.